### PR TITLE
DOC: Documentation build info and latest docker image update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ nbproject
 my_clang_cache.cmake
 # ccache specific configs
 /ccache/
+# documentation artifacts
+doc/_build/
+doc/html/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The most up to date documentation can be found at:
 http://eos-docs.web.cern.ch/eos-docs/
 
 
-**Doxygent** documentation of the API is available in the ``./doc`` directory
+**Doxygen** documentation of the API is available in the ``./doc`` directory
  and can be generated using the following command:
 
 ```bash
@@ -28,6 +28,16 @@ doxygen
 ....
 # Documentation generated in the ./html directory which can be accessed using any browser
 # file:///eos_git_clone_dir/doc/html/index.html
+```
+
+**Sphinx** documentation of installation and application is also in the ``./doc'' directory
+This is what is published in https://eos-docs.web.cern.ch
+Documentation can be generated using the following command
+```bash
+cd doc
+make html
+# Documentation can be found in build/html/index.html
+
 ```
 
 ## Project Directory Structure

--- a/doc/quickstart/docker_image.rst
+++ b/doc/quickstart/docker_image.rst
@@ -47,9 +47,11 @@ The arguments to provide are the name of the image to use with the **-i** and th
 
 The containers will reside on the same network knowing about each other and are configured to be working out-of-the-box.
 
+You are likely to have the best results with the latest release shown in <https://eos-docs.web.cern.ch/releases.html>.  These instructions assume that it is 4.8.39.
+
 .. code-block:: bash
 
-   scripts/start_services.sh -i gitlab-registry.cern.ch/dss/eos:4.2.16 -n 6
+   scripts/start_services.sh -i gitlab-registry.cern.ch/dss/eos:4.8.39 -n 6
 
 To connect to EOS using the *eos* shell CLI running in the MGM container you can do:
 
@@ -65,8 +67,8 @@ To connect to EOS using the *eos* shell CLI running in the MGM container you can
    EOS Console [root://localhost] |/> version
    version
    EOS_INSTANCE=eosdockertest
-   EOS_SERVER_VERSION=4.2.16 EOS_SERVER_RELEASE=1
-   EOS_CLIENT_VERSION=4.2.16 EOS_CLIENT_RELEASE=1
+   EOS_SERVER_VERSION=4.8.39 EOS_SERVER_RELEASE=1
+   EOS_CLIENT_VERSION=4.8.39 EOS_CLIENT_RELEASE=1
 
 .. code-block:: bash
 


### PR DESCRIPTION
README.md now indicates that API and main documentation are built differently.  The .gitignore now ignores the generated files.  Docker quickstart has latest image and indicates where to find out the latest.