### PR TITLE
Force expiring automounts breaks cvmfs namespaced mounts

### DIFF
--- a/eos.spec.in
+++ b/eos.spec.in
@@ -783,11 +783,6 @@ if [ "$1" -ge "1" ]; then # Upgrade
   do
     /usr/sbin/semodule -i %{_datarootdir}/selinux/$VARIANT/eosfuse.pp || :
   done
-
-  # If the automount daemon catches a USR1 signal, it will umount all currently
-  # unused autofs managed mounted filesystems and continue running (forced
-  # expire).
-  /usr/bin/killall --quiet --signal USR1 automount ||:
 fi
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Currently the eos-core package forces an automount expiry of all
unused automounted filesystems.

Unfortunately this can cause CvmFS mounts which are only used within
a namespace to break[4]. The only protection we have currently
against this to run an external process that pings mounts in
the main namespace that are mounted in a namespace only. [3]

However this forced expiry causes them to unmount anyway resulting
in broken mounts.

This is fixed[1] in kernel 5.15  but that that is some time of from
production of course.

Trying to reproduce this with EOS it behaves slightly differently.

```
server> ls /eos/user/u/user
server> podman run -it -v $XDG_RUNTIME_DIR/krb5cc:/tmp/krb5cc_0 -v /eos:/eos gitlab-registry.cern.ch/linuxsupport/c8-base /bin/bash
container> ls /eos/user/u/user
server> /usr/bin/killall --quiet --signal USR1 automount
container> mount | eos
/etc/auto.eos on /eos type autofs (rw,relatime,fd=24,pgrp=0,timeout=200,minproto=5,maxproto=5,indirect,pipe_ino=368651)
user on /eos/user type fuse (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
home-s on /eos/home-s type fuse (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
server>  mount | eos
/etc/auto.eos on /eos type autofs (rw,relatime,fd=24,pgrp=10607,timeout=200,minproto=5,maxproto=5,indirect,pipe_ino=368651)
```
It expires the mount outside but you can still mount again with a ls on
the outside. With CvmFS the outside mount is broken. That is intresting
for CvmFS but this forced expire should still go I believe. The timeout
will do the job.

There's some background in CvmFS ticket[2]

* [1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v5.15-rc1&id=5d5b74aa9c766f0dd37d5cc1a2a7a94586130501
* [2] https://sft.its.cern.ch/jira/browse/CVM-2004
* [3] https://gitlab.cern.ch/batch-team/rpms/cvmfs-keep-alive
* [4] https://sft.its.cern.ch/jira/browse/CVM-2063