### PR TITLE
installation docs: fix table syntax for dependency repo, add double t…

### DIFF
--- a/doc/diopside/manual/hardware-installation.rst
+++ b/doc/diopside/manual/hardware-installation.rst
@@ -141,42 +141,43 @@ You have to configure a dependency repository and either the tag or commit repos
 **Dependency Repository for Tag and Commit Releases**
 
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Platform        | Setup                                                                                                              | 
+| Platform        | Setup                                                                                                              |
 +=================+====================================================================================================================+
-| CentOS7         | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-7/x86_64/"         |
+| CentOS7         | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-7/x86_64/"``     |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 8          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-8/x86_64/"         |
+| Alma 8          | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-8/x86_64/"``     |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 9          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-9/x86_64/"        |
+| Alma 9          | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-9/x86_64/"``     |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
 | Fedora 38       | https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/fc-38/                                               |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
 
 **Tag Releases**
 
-+-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Platform        |  Setup                                                                                                             | 
-+=================+====================================================================================================================+
-| CentOS7         | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/el-7/x86_64/"    |
-+-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 8          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/el-8/x86_64/"    |
-+-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 9          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/el-8s/x86_64/"   |
-+-----------------+--------------------------------------------------------------------------------------------------------------------+
-| CentOS9 Stream  | https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/fc-38/x86_64/"                                  |
-+-----------------+--------------------------------------------------------------------------------------------------------------------+
++-----------------+-----------------------------------------------------------------------------------------------------------------------+
+| Platform        |  Setup                                                                                                                |
++=================+=======================================================================================================================+
+| CentOS7         | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/el-7/x86_64/"``   |
++-----------------+-----------------------------------------------------------------------------------------------------------------------+
+| Alma 8          | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/el-8/x86_64/"``   |
++-----------------+-----------------------------------------------------------------------------------------------------------------------+
+| Alma 9          | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/el-8s/x86_64/"``  |
+|                 |                                                                                                                       |
++-----------------+-----------------------------------------------------------------------------------------------------------------------+
+| CentOS9 Stream  | https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/fc-38/x86_64/"                                     |
++-----------------+-----------------------------------------------------------------------------------------------------------------------+
 
 
 **Commit Releases**
 
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Platform        |  Setup                                                                                                             | 
+| Platform        |  Setup                                                                                                             |
 +=================+====================================================================================================================+
-| CentOS7         |  yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/commit/el-7/x86_64/"        |
+| CentOS7         | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/commit/el-7/x86_64/"``     |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 8          |  yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/commit/el-8/x86_64/"        |
+| Alma 8          |  ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/commit/el-8/x86_64/"``    |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 9          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/commit/el-8s/x86_64/"        |
+| Alma 9          | ``yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside/commit/el-8s/x86_64/"``    |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
 | Fedora 38       | https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/fc-38/x86_64/"                                  |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
…icks to prevent unicodisation of yum commands

Dear EOS folks,

In your documentation page
https://eos-docs.web.cern.ch/diopside/manual/hardware-installation.html#eos-for-client-server

The table syntax is broken for the "dependency repos" which makes it disappear on the actual page
Here is a patch
```diff

 +-----------------+--------------------------------------------------------------------------------------------------------------------+
 | Platform        | Setup                                                                                                              | 
 +=================+=============================================================================================== =====================+
 | CentOS7         | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-7/x86_64/"         |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
 | Alma 8          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-8/x86_64/"         |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
-| Alma 9          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-9/x86_64/"        |
+| Alma 9          | yum-config-manager --add-repo "https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/el-9/x86_64/"         |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
 | Fedora 38       | https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/fc-38/                                               |
 +-----------------+--------------------------------------------------------------------------------------------------------------------+
```

And the page turns the commands into unicode -- and " " which breaks copy paste, which is _really_ annoying, I think surrounding things with double ticks should work.

Thanks for your consideration!

