### PR TITLE
MISC: fix typos in alice module

### DIFF
--- a/misc/etc/eos/config/modules/alice
+++ b/misc/etc/eos/config/modules/alice
@@ -38,13 +38,13 @@ if [ $? -ne 0 ]; then
   adduser --uid ${ALICE_UID}  alice
 fi
 
-eos vid set map \<pwd\> -unix vuid:${ALICE_UID}
-eos vid set map \<pwd\> -unix vgid:${ALICE_GID}
+eos vid set map -unix \<pwd\> vuid:${ALICE_UID}
+eos vid set map -unix \<pwd\> vgid:${ALICE_GID}
 eos mkdir -p /eos/${INSTANCE_NAME:3}/grid/
 eos chown ${ALICE_UID}:${ALICE_GID} /eos/${INSTANCE_NAME:3}/grid/
 eos chmod 700 /eos/${INSTANCE_NAME:3}/grid/
 
-for name in 01 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 ; do
+for name in 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 ; do
   eos map link /$name/ /eos/${INSTANCE_NAME:3}/grid/$name/
   eos mkdir -p /eos/${INSTANCE_NAME:3}/grid/$name/
 done


### PR DESCRIPTION
The alice module had a few issues, it created the "01" link two times instead of "00" and "01", and the options order for "vid set" was wrong.